### PR TITLE
amount validation- fix empty sum bug at other sum input

### DIFF
--- a/client/src/pages/Funding/validations.js
+++ b/client/src/pages/Funding/validations.js
@@ -1,5 +1,5 @@
 export const paymentRequestValidation = ({ amount, termsAccepted }) => {
-	const isValidAmount = Number.isInteger(amount);
+	const isValidAmount = Number.isInteger(amount) && parseInt(amount) > 0
 	const isValidAcceptedTerms =  termsAccepted || false;
 
 	return { isValidAmount, isValidAcceptedTerms}
@@ -7,14 +7,16 @@ export const paymentRequestValidation = ({ amount, termsAccepted }) => {
 
 const termsNotAccepted = 'נא לאשר את תנאי התמיכה'
 const undefinedAmountMessage = 'נא לבחור סכום לתמיכה'
+const emptyAmountMessage = 'נא להזין סכום לתמיכה';
 const emptyString = ''
 
 export const getFormErrors = ({ 
-	validations: { isValidAmount, isValidAcceptedTerms }}) => {
-	
-	const amountError = { 
+	validations: { isValidAmount, isValidAcceptedTerms },
+	values: { amount, termsAccepted }
+}) => {	
+	let  amountError = { 
 		isValid: isValidAmount,
-		message: isValidAmount ? emptyString : undefinedAmountMessage
+		message: isValidAmount ? emptyString : Number.isInteger(amount) ? emptyAmountMessage: undefinedAmountMessage
 	}
 	const termsAcceptedError = { 
 		isValid: isValidAcceptedTerms, 


### PR DESCRIPTION
There was a bug in the support_us page at other sum amount- when a user selected the other sum input and didn't enter any value, the default value "0" is sent to server. This adds a validation to the sum to make sure it is not empty and bigger than 0 