### PR TITLE
add employment, hoteliery & commerce tags

### DIFF
--- a/server/api/constants.js
+++ b/server/api/constants.js
@@ -14,6 +14,13 @@ exports.personTypes = {
 	'6': 'אחר'
 };
 
+const area_change_types =  {
+	NEW_USAGE: 'NEW_USAGE',
+	INCREASED_USAGE: 'INCREASED_USAGE'
+};
+
+exports.area_change_types = area_change_types;
+
 exports.tagDataRules = 
 [
 	{
@@ -23,12 +30,30 @@ exports.tagDataRules =
 		 {
 			usage: 'מגורים (מ"ר)' ,
 			minValue: 1000,
-			description: 'adds more than 1,000 Sq Meters of housing'
+			description: 'adds more than 1,000 Sq Meters of housing',
+			changeType: area_change_types.INCREASED_USAGE
 		},
 		 {
 			usage: 'מגורים (יח"ד)',
 			minValue: 10,
-			description: 'adds more than 10 units of housing'
+			description: 'adds more than 10 units of housing',
+			changeType: area_change_types.INCREASED_USAGE
+		}]
+	},
+	{ 
+	tagId: 2,
+	tagName: 'תעסוקה ותעשיה',
+	rules: [
+		{
+			usage: 'תעסוקה (מ"ר)' ,
+			minValue: 2000,
+			description: 'adds more than 2,000 Sq Meters of employment',
+			changeType: area_change_types.INCREASED_USAGE
+		},{
+			usage: 'תעסוקה (מ"ר)' ,
+			minValue: 200,
+			description: 'adds more than 200 Sq Meters of employment, completely new',
+			changeType: area_change_types.NEW_USAGE
 		}]
 	},
 	{ 
@@ -38,9 +63,10 @@ exports.tagDataRules =
 		{
 			usage: 'מבני ציבור (מ"ר)' ,
 			minValue: 50,
-			description: 'adds more than 50 Sq Meters of public area'
+			description: 'adds more than 50 Sq Meters of public area',
+			changeType: area_change_types.INCREASED_USAGE
 		}]
-}
+	}
 
 ]
 	

--- a/server/api/constants.js
+++ b/server/api/constants.js
@@ -41,7 +41,7 @@ exports.tagDataRules =
 		}]
 	},
 	{ 
-	tagName: 'תעסוקה ותעשיה',
+	tagName: 'תעסוקה',
 	rules: [
 		{
 			usage: 'תעסוקה (מ"ר)' ,

--- a/server/api/constants.js
+++ b/server/api/constants.js
@@ -14,95 +14,94 @@ exports.personTypes = {
 	'6': 'אחר'
 };
 
-const area_change_types =  {
+const AREA_CHANGE_TYPES =  {
 	NEW_USAGE: 'NEW_USAGE',
 	INCREASED_USAGE: 'INCREASED_USAGE',
 	PERCENT_INCREASE: 'PERCENT_INCREASE'
 };
-
-exports.area_change_types = area_change_types;
+exports.AREA_CHANGE_TYPES = AREA_CHANGE_TYPES;
 
 exports.tagDataRules = 
 [
 	{
-	tagName: 'דיור',
+	tagName: 'Housing',
 	rules: [
 		 {
 			usage: 'מגורים (מ"ר)' ,
 			minValue: 1000,
 			description: 'adds more than 1,000 Sq Meters of housing',
-			changeType: area_change_types.INCREASED_USAGE
+			changeType: AREA_CHANGE_TYPES.INCREASED_USAGE
 		},
 		 {
 			usage: 'מגורים (יח"ד)',
 			minValue: 10,
 			description: 'adds more than 10 units of housing',
-			changeType: area_change_types.INCREASED_USAGE
+			changeType: AREA_CHANGE_TYPES.INCREASED_USAGE
 		}]
 	},
 	{ 
-	tagName: 'תעסוקה',
+	tagName: 'Employment',
 	rules: [
 		{
 			usage: 'תעסוקה (מ"ר)' ,
 			minValue: 2000,
 			description: 'adds more than 2,000 Sq Meters of commerce to plan with existing commerce',
-			changeType: area_change_types.INCREASED_USAGE
+			changeType: AREA_CHANGE_TYPES.INCREASED_USAGE
 		},{
 			usage: 'תעסוקה (מ"ר)' ,
 			minValue: 200,
 			description: 'adds more than 200 Sq Meters of employment, completely new',
-			changeType: area_change_types.NEW_USAGE
+			changeType: AREA_CHANGE_TYPES.NEW_USAGE
 		}]
 	},
 	{ 
-	tagName: 'מבני ציבור',
+	tagName: 'Public',
 	rules: [
 		{
 			usage: 'מבני ציבור (מ"ר)' ,
 			minValue: 50,
 			description: 'adds more than 50 Sq Meters of public area',
-			changeType: area_change_types.INCREASED_USAGE
+			changeType: AREA_CHANGE_TYPES.INCREASED_USAGE
 		}]
 	},
 	{ 
-		tagName: 'מסחר',
+		tagName: 'Commerce',
 		rules: [
 			{
 				usage: 'מסחר (מ"ר)' ,
 				minValue: 100 ,
 				description: 'adds more than 100 Sq Meters of commerce',
-				changeType: area_change_types.INCREASED_USAGE
+				changeType: AREA_CHANGE_TYPES.INCREASED_USAGE
 			},			{
 				usage: 'מסחר (מ"ר)' ,
 				minValue: 1 ,
 				description: 'adds any Sq Meters of commerce where there was none',
-				changeType: area_change_types.NEW_USAGE
+				changeType: AREA_CHANGE_TYPES.NEW_USAGE
 			},			{
 				usage: 'מסחר (מ"ר)' ,
 				minValue: 20 ,
 				description: 'adds more than 20% commerce',
-				changeType: area_change_types.PERCENT_INCREASE
+				changeType: AREA_CHANGE_TYPES.PERCENT_INCREASE
 			}]
 		},	
 		{ 
-			tagName: 'תיירות',
+			tagName: 'Hoteliery',
 			rules: [
 				{
 					usage: 'חדרי מלון / תיירות (מ"ר)' ,
 					minValue: 200 ,
 					description: 'adds more than 200 Sq Meters of hoteliery',
-					changeType: area_change_types.INCREASED_USAGE
+					changeType: AREA_CHANGE_TYPES.INCREASED_USAGE
 				},			{
 					usage: 'חדרי מלון / תיירות (מ"ר)' ,
 					minValue: 1 ,
 					description: 'adds any Sq Meters of hoteliery where there was none',
-					changeType: area_change_types.NEW_USAGE
+					changeType: AREA_CHANGE_TYPES.NEW_USAGE
 				},			{
 					usage: 'חדרי מלון / תיירות (מ"ר)' ,
 					minValue: 30 ,
 					description: 'adds more than 30% hoteliery',
-					changeType: area_change_types.PERCENT_INCREASE
+					changeType: AREA_CHANGE_TYPES.PERCENT_INCREASE
 				}]
 			},
 ]

--- a/server/api/constants.js
+++ b/server/api/constants.js
@@ -16,7 +16,8 @@ exports.personTypes = {
 
 const area_change_types =  {
 	NEW_USAGE: 'NEW_USAGE',
-	INCREASED_USAGE: 'INCREASED_USAGE'
+	INCREASED_USAGE: 'INCREASED_USAGE',
+	PERCENT_INCREASE: 'PERCENT_INCREASE'
 };
 
 exports.area_change_types = area_change_types;
@@ -47,7 +48,7 @@ exports.tagDataRules =
 		{
 			usage: 'תעסוקה (מ"ר)' ,
 			minValue: 2000,
-			description: 'adds more than 2,000 Sq Meters of employment',
+			description: 'adds more than 2,000 Sq Meters of commerce to plan with existing commerce',
 			changeType: area_change_types.INCREASED_USAGE
 		},{
 			usage: 'תעסוקה (מ"ר)' ,
@@ -66,8 +67,49 @@ exports.tagDataRules =
 			description: 'adds more than 50 Sq Meters of public area',
 			changeType: area_change_types.INCREASED_USAGE
 		}]
-	}
-
+	},
+	{ 
+		tagId: 17,
+		tagName: 'מסחר',
+		rules: [
+			{
+				usage: 'מסחר (מ"ר)' ,
+				minValue: 100 ,
+				description: 'adds more than 100 Sq Meters of commerce',
+				changeType: area_change_types.INCREASED_USAGE
+			},			{
+				usage: 'מסחר (מ"ר)' ,
+				minValue: 1 ,
+				description: 'adds any Sq Meters of commerce where there was none',
+				changeType: area_change_types.NEW_USAGE
+			},			{
+				usage: 'מסחר (מ"ר)' ,
+				minValue: 20 ,
+				description: 'adds more than 20% commerce',
+				changeType: area_change_types.PERCENT_INCREASE
+			}]
+		},	
+		{ 
+			tagId: 18,
+			tagName: 'תיירות',
+			rules: [
+				{
+					usage: 'חדרי מלון / תיירות (מ"ר)' ,
+					minValue: 200 ,
+					description: 'adds more than 200 Sq Meters of hoteliery',
+					changeType: area_change_types.INCREASED_USAGE
+				},			{
+					usage: 'חדרי מלון / תיירות (מ"ר)' ,
+					minValue: 1 ,
+					description: 'adds any Sq Meters of hoteliery where there was none',
+					changeType: area_change_types.NEW_USAGE
+				},			{
+					usage: 'חדרי מלון / תיירות (מ"ר)' ,
+					minValue: 30 ,
+					description: 'adds more than 30% hoteliery',
+					changeType: area_change_types.PERCENT_INCREASE
+				}]
+			},
 ]
 	
 	

--- a/server/api/constants.js
+++ b/server/api/constants.js
@@ -25,7 +25,6 @@ exports.area_change_types = area_change_types;
 exports.tagDataRules = 
 [
 	{
-	tagId: 1,
 	tagName: 'דיור',
 	rules: [
 		 {
@@ -42,7 +41,6 @@ exports.tagDataRules =
 		}]
 	},
 	{ 
-	tagId: 2,
 	tagName: 'תעסוקה ותעשיה',
 	rules: [
 		{
@@ -58,7 +56,6 @@ exports.tagDataRules =
 		}]
 	},
 	{ 
-	tagId: 3,
 	tagName: 'מבני ציבור',
 	rules: [
 		{
@@ -69,7 +66,6 @@ exports.tagDataRules =
 		}]
 	},
 	{ 
-		tagId: 17,
 		tagName: 'מסחר',
 		rules: [
 			{
@@ -90,7 +86,6 @@ exports.tagDataRules =
 			}]
 		},	
 		{ 
-			tagId: 18,
 			tagName: 'תיירות',
 			rules: [
 				{

--- a/server/api/lib/tags/commerce.js
+++ b/server/api/lib/tags/commerce.js
@@ -4,10 +4,11 @@
 const { doesTagApplyHelper} = require('../tags/utils');
 const TAG_NAME = 'מסחר';
 
-const doesTagApply = async (planId) => {  
-	return doesTagApplyHelper(planId,TAG_NAME);
+const doesTagApply = async (planId, tagsResources) => {  
+	return doesTagApplyHelper(planId,TAG_NAME, tagsResources);
 }
 
 module.exports = {
-	doesTagApply
+	doesTagApply, 
+	TAG_NAME
 };

--- a/server/api/lib/tags/commerce.js
+++ b/server/api/lib/tags/commerce.js
@@ -1,0 +1,13 @@
+// Commerce: (request to build a completely new commerce area [not an addition to an existing one]) 
+// or (request to build more than 100 mr of commerce) 
+// or (request to enlarge existing building rights of commerce by more than 20%).
+const { doesTagApplyHelper} = require('../tags/utils');
+const TAG_NAME = 'מסחר';
+
+const doesTagApply = async (planId) => {  
+	return doesTagApplyHelper(planId,TAG_NAME);
+}
+
+module.exports = {
+	doesTagApply
+};

--- a/server/api/lib/tags/commerce.js
+++ b/server/api/lib/tags/commerce.js
@@ -2,7 +2,8 @@
 // or (request to build more than 100 mr of commerce) 
 // or (request to enlarge existing building rights of commerce by more than 20%).
 const { doesTagApplyHelper} = require('../tags/utils');
-const TAG_NAME = 'מסחר';
+const TAG_NAME = 'Commerce';
+const TAG_DISPLAY_NAME = 'מסחר';
 
 const doesTagApply = async (planId, tagsResources) => {  
 	return doesTagApplyHelper(planId,TAG_NAME, tagsResources);
@@ -10,5 +11,6 @@ const doesTagApply = async (planId, tagsResources) => {
 
 module.exports = {
 	doesTagApply, 
-	TAG_NAME
+	TAG_NAME,
+	TAG_DISPLAY_NAME
 };

--- a/server/api/lib/tags/employment.js
+++ b/server/api/lib/tags/employment.js
@@ -4,10 +4,11 @@
 const { doesTagApplyHelper} = require('../tags/utils');
 const TAG_NAME = 'תעסוקה ותעשיה';
 
-const doesTagApply = async (planId) => {  
-	return doesTagApplyHelper(planId,TAG_NAME);
+const doesTagApply = async (planId, tagsResources) => {  
+	return doesTagApplyHelper(planId,TAG_NAME, tagsResources);
 }
 
 module.exports = {
-	doesTagApply
+	doesTagApply, 
+	TAG_NAME
 };

--- a/server/api/lib/tags/employment.js
+++ b/server/api/lib/tags/employment.js
@@ -2,7 +2,8 @@
 // (request to build a completely new employment area with a size bigger than 200 mr [not an addition to an existing one]) 
 // or (request to build more than 2000 mr of employment).
 const { doesTagApplyHelper} = require('../tags/utils');
-const TAG_NAME = 'תעסוקה';
+const TAG_NAME = 'Employment';
+const TAG_DISPLAY_NAME = 'תעסוקה';
 
 const doesTagApply = async (planId, tagsResources) => {  
 	return doesTagApplyHelper(planId,TAG_NAME, tagsResources);
@@ -10,5 +11,6 @@ const doesTagApply = async (planId, tagsResources) => {
 
 module.exports = {
 	doesTagApply, 
-	TAG_NAME
+	TAG_NAME,
+	TAG_DISPLAY_NAME
 };

--- a/server/api/lib/tags/employment.js
+++ b/server/api/lib/tags/employment.js
@@ -1,0 +1,13 @@
+// Employment  tag applies Employment: 
+// (request to build a completely new employment area with a size bigger than 200 mr [not an addition to an existing one]) 
+// or (request to build more than 2000 mr of employment).
+const { doesTagApplyHelper} = require('../tags/utils');
+const TAG_NAME = 'תעסוקה ותעשיה';
+
+const doesTagApply = async (planId) => {  
+	return doesTagApplyHelper(planId,TAG_NAME);
+}
+
+module.exports = {
+	doesTagApply
+};

--- a/server/api/lib/tags/employment.js
+++ b/server/api/lib/tags/employment.js
@@ -2,7 +2,7 @@
 // (request to build a completely new employment area with a size bigger than 200 mr [not an addition to an existing one]) 
 // or (request to build more than 2000 mr of employment).
 const { doesTagApplyHelper} = require('../tags/utils');
-const TAG_NAME = 'תעסוקה ותעשיה';
+const TAG_NAME = 'תעסוקה';
 
 const doesTagApply = async (planId, tagsResources) => {  
 	return doesTagApplyHelper(planId,TAG_NAME, tagsResources);

--- a/server/api/lib/tags/hoteliery.js
+++ b/server/api/lib/tags/hoteliery.js
@@ -1,0 +1,14 @@
+// Hoteliery: (request to build a completely new hotel [not an addition to an existing one]) or
+// (request to build more than 200 mr of hoteliery) or
+// (request to enlarge existing building rights of hoteliery by more than 30%).
+const { doesTagApplyHelper} = require('../tags/utils');
+const TAG_NAME = 'תיירות';
+
+const doesTagApply = async (planId) => {  
+	return doesTagApplyHelper(planId,TAG_NAME);
+}
+
+module.exports = {
+	doesTagApply
+};
+

--- a/server/api/lib/tags/hoteliery.js
+++ b/server/api/lib/tags/hoteliery.js
@@ -4,11 +4,12 @@
 const { doesTagApplyHelper} = require('../tags/utils');
 const TAG_NAME = 'תיירות';
 
-const doesTagApply = async (planId) => {  
-	return doesTagApplyHelper(planId,TAG_NAME);
+const doesTagApply = async (planId, tagsResources) => {  
+	return doesTagApplyHelper(planId,TAG_NAME, tagsResources);
 }
 
 module.exports = {
-	doesTagApply
+	doesTagApply, 
+	TAG_NAME
 };
 

--- a/server/api/lib/tags/hoteliery.js
+++ b/server/api/lib/tags/hoteliery.js
@@ -2,7 +2,8 @@
 // (request to build more than 200 mr of hoteliery) or
 // (request to enlarge existing building rights of hoteliery by more than 30%).
 const { doesTagApplyHelper} = require('../tags/utils');
-const TAG_NAME = 'תיירות';
+const TAG_NAME = 'Hoteliery';
+const TAG_DISPLAY_NAME = 'מלונאות';
 
 const doesTagApply = async (planId, tagsResources) => {  
 	return doesTagApplyHelper(planId,TAG_NAME, tagsResources);
@@ -10,6 +11,7 @@ const doesTagApply = async (planId, tagsResources) => {
 
 module.exports = {
 	doesTagApply, 
-	TAG_NAME
+	TAG_NAME,
+	TAG_DISPLAY_NAME
 };
 

--- a/server/api/lib/tags/housing.js
+++ b/server/api/lib/tags/housing.js
@@ -1,11 +1,13 @@
 // Housing tag applies if the change to either housing by area or housing by units meets the minimum threshold
 const { doesTagApplyHelper} = require('../tags/utils');
+
 const TAG_NAME = 'דיור';
 
-const doesTagApply = async (planId) => {  
-	return doesTagApplyHelper(planId,TAG_NAME);
-}
+const doesTagApply = async (plan, tagsResources) => {
+	return doesTagApplyHelper(plan, TAG_NAME, tagsResources);
+};
 
 module.exports = {
-	doesTagApply
+	doesTagApply,
+	TAG_NAME
 };

--- a/server/api/lib/tags/housing.js
+++ b/server/api/lib/tags/housing.js
@@ -3,8 +3,8 @@ const { doesTagApplyHelper} = require('../tags/utils');
 const TAG_NAME = 'Housing';
 const TAG_DISPLAY_NAME = 'דיור';
 
-const doesTagApply = async (plan, tagsResources) => {
-	return doesTagApplyHelper(plan, TAG_NAME, tagsResources);
+const doesTagApply = async (planId, tagsResources) => {
+	return doesTagApplyHelper(planId, TAG_NAME, tagsResources);
 };
 
 module.exports = {

--- a/server/api/lib/tags/housing.js
+++ b/server/api/lib/tags/housing.js
@@ -1,7 +1,7 @@
 // Housing tag applies if the change to either housing by area or housing by units meets the minimum threshold
 const { doesTagApplyHelper} = require('../tags/utils');
-
-const TAG_NAME = 'דיור';
+const TAG_NAME = 'Housing';
+const TAG_DISPLAY_NAME = 'דיור';
 
 const doesTagApply = async (plan, tagsResources) => {
 	return doesTagApplyHelper(plan, TAG_NAME, tagsResources);
@@ -9,5 +9,6 @@ const doesTagApply = async (plan, tagsResources) => {
 
 module.exports = {
 	doesTagApply,
-	TAG_NAME
+	TAG_NAME,
+	TAG_DISPLAY_NAME
 };

--- a/server/api/lib/tags/index.js
+++ b/server/api/lib/tags/index.js
@@ -1,6 +1,6 @@
 
 const Exception = require('../../../api/model/exception');
-const functions = [require('../tags/housing'),require('../tags/public')];
+const functions = [require('../tags/housing'),require('../tags/public'),require('../tags/employment')];
 
 const generateTagsForPlan = async (planId) => {
 	const planTags = [];

--- a/server/api/lib/tags/index.js
+++ b/server/api/lib/tags/index.js
@@ -1,6 +1,6 @@
 
 const Exception = require('../../../api/model/exception');
-const functions = [require('../tags/housing'),require('../tags/public'),require('../tags/employment')];
+const functions = [require('../tags/housing'),require('../tags/public'),require('../tags/employment'),require('../tags/commerce'),require('../tags/hoteliery')];
 
 const generateTagsForPlan = async (planId) => {
 	const planTags = [];

--- a/server/api/lib/tags/index.js
+++ b/server/api/lib/tags/index.js
@@ -1,25 +1,37 @@
-
 const Exception = require('../../../api/model/exception');
-const functions = [require('../tags/housing'),require('../tags/public'),require('../tags/employment'),require('../tags/commerce'),require('../tags/hoteliery')];
+const { getTagsResources } = require('../tags/tags_resources');
 
-const generateTagsForPlan = async (planId) => {
-	const planTags = [];
-	for (const counter in functions) {
-		const tagFunction = functions[counter];
-		try {
-			if (typeof(tagFunction.doesTagApply) != "function") {
-				throw new Exception.BadRequest(`"Please require only doesTagApply functions.`);
-			};
-			const result = await tagFunction.doesTagApply(planId);
-			planTags.push(...result);
-		} catch (err) {
-			console.debug(err);			
+const housingTag = require('../tags/housing');
+const publicBuildingsTag = require('../tags/public');
+const EmploymentTag = require('../tags/employment');
+const HotelieryTag = require('../tags/hoteliery');
+const CommerceTag = require('../tags/commerce');
+
+const taggingFunctions = [
+	housingTag,
+	publicBuildingsTag,
+	EmploymentTag,
+	HotelieryTag,
+	CommerceTag
+];
+
+const getPlanTagger = async () => {
+	const resources = await getTagsResources();
+	return async (plan) => {
+		const planTags = [];
+		for (const tagFunction of taggingFunctions) {
+			const result = await tagFunction.doesTagApply(plan.id, resources);
+
+			if (result !== null) {
+				planTags.push(result);
+			}
+
 		}
-			
-	} 
-	return planTags;	
-}
+		return planTags;
+	};
+};
+
 
 module.exports = {
-	generateTagsForPlan
+	getPlanTagger
 };

--- a/server/api/lib/tags/public.js
+++ b/server/api/lib/tags/public.js
@@ -1,11 +1,13 @@
 // Public area tag applies if the change to either public area meets the minimum threshold
 const { doesTagApplyHelper} = require('../tags/utils');
+
 const TAG_NAME = 'מבני ציבור';
 
-const doesTagApply = async (planId) => {  
-	return doesTagApplyHelper(planId,TAG_NAME);
-}
+const doesTagApply = async (plan, tagsResources) => {
+	return doesTagApplyHelper(plan, TAG_NAME, tagsResources);
+};
 
 module.exports = {
-	doesTagApply
+	doesTagApply,
+	TAG_NAME
 };

--- a/server/api/lib/tags/public.js
+++ b/server/api/lib/tags/public.js
@@ -3,8 +3,8 @@ const { doesTagApplyHelper} = require('../tags/utils');
 const TAG_NAME = 'Public';
 const TAG_DISPLAY_NAME = 'מבני ציבור';
 
-const doesTagApply = async (plan, tagsResources) => {
-	return doesTagApplyHelper(plan, TAG_NAME, tagsResources);
+const doesTagApply = async (planId, tagsResources) => {
+	return doesTagApplyHelper(planId, TAG_NAME, tagsResources);
 };
 
 module.exports = {

--- a/server/api/lib/tags/public.js
+++ b/server/api/lib/tags/public.js
@@ -1,7 +1,7 @@
 // Public area tag applies if the change to either public area meets the minimum threshold
 const { doesTagApplyHelper} = require('../tags/utils');
-
-const TAG_NAME = 'מבני ציבור';
+const TAG_NAME = 'Public';
+const TAG_DISPLAY_NAME = 'מבני ציבור';
 
 const doesTagApply = async (plan, tagsResources) => {
 	return doesTagApplyHelper(plan, TAG_NAME, tagsResources);
@@ -9,5 +9,6 @@ const doesTagApply = async (plan, tagsResources) => {
 
 module.exports = {
 	doesTagApply,
-	TAG_NAME
+	TAG_NAME,
+	TAG_DISPLAY_NAME
 };

--- a/server/api/lib/tags/tags_resources.js
+++ b/server/api/lib/tags/tags_resources.js
@@ -1,0 +1,23 @@
+const Tag = require('../../model/tag');
+
+
+const getTagsResources = async () => {
+
+    const tagsInDb = await Tag.fetchAll({
+        columns: ['id', 'name']
+    });
+
+    const tagNameToTagId = {};
+    for (const model of tagsInDb.models) {
+        tagNameToTagId[model.attributes.name] = model.id;
+    }
+
+    return {
+        tagNameToTagId: tagNameToTagId
+    };
+
+};
+
+module.exports = {
+    getTagsResources
+};

--- a/server/api/lib/tags/utils.js
+++ b/server/api/lib/tags/utils.js
@@ -1,5 +1,5 @@
 const PlanAreaChanges = require('../../../api/model/plan_area_changes');
-const { tagDataRules, area_change_types } = require('../../constants');
+const { tagDataRules, AREA_CHANGE_TYPES } = require('../../constants');
 
 const isTagByUsageAddition = async (planId, rule) => {
 	try {
@@ -8,7 +8,7 @@ const isTagByUsageAddition = async (planId, rule) => {
 			const changeToApprovedState = result.models[0].attributes.change_to_approved_state;
 			const approvedState = result.models[0].attributes.approved_state;
 			switch (rule.changeType) {
-				case area_change_types.INCREASED_USAGE:
+				case AREA_CHANGE_TYPES.INCREASED_USAGE:
 					// change to approved state
 					if ((changeToApprovedState.length > 1) && 
 						(changeToApprovedState.substring(0,1) === '+') ) {
@@ -20,7 +20,7 @@ const isTagByUsageAddition = async (planId, rule) => {
 						}
 					}					
 					break;	
-				case area_change_types.NEW_USAGE:
+				case AREA_CHANGE_TYPES.NEW_USAGE:
 					// new usage that was not approved previously
 					if ((changeToApprovedState.length > 1) && 
 					(changeToApprovedState.substring(0,1) === '+') && 
@@ -33,7 +33,7 @@ const isTagByUsageAddition = async (planId, rule) => {
 						}	
 					}
 					break;
-				case area_change_types.PERCENT_INCREASE:
+				case AREA_CHANGE_TYPES.PERCENT_INCREASE:
 						// usage that grows by a certain percentage
 						if ((changeToApprovedState.length > 1) && 
 						(changeToApprovedState.substring(0,1) === '+') && 

--- a/server/api/lib/tags/utils.js
+++ b/server/api/lib/tags/utils.js
@@ -51,17 +51,17 @@ const isTagByUsageAddition = async (planId, rule) => {
 		console.log(`error ${error.message}\n`);
 		console.debug(error);
 	}
-}
+};
 
-const doesTagApplyHelper = async (planId,tagName) => {  
-	const planTags = [];
-	const dataRules = [];	
-	const tagInfo = tagDataRules.filter(tag => {return tag.tagName===tagName})[0];
-	const tagId = tagInfo.tagId;
+const doesTagApplyHelper = async (planId, tagName, tagsResources) => {
+	const dataRules = [];
+	const tagInfo = tagDataRules.filter(tag => {return tag.tagName === tagName})[0];
 	for (const counter in tagInfo.rules) {
+
 		const rule = tagInfo.rules[counter];
 		try {
 			const isTag = await isTagByUsageAddition(planId, rule);
+
 			if (isTag) {
 				dataRules.push(
 					isTag.created_by_data_rules
@@ -73,16 +73,18 @@ const doesTagApplyHelper = async (planId,tagName) => {
 		}
 			
 	} 
-	if (dataRules.length>0) {
-		planTags.push( {
+	if (dataRules.length > 0) {
+		return {
 			plan_id: planId,
-			tag_id: tagId,
+			tag_id: tagsResources.tagNameToTagId[tagName],
 			display_score: 0, /* TODO: Add the correct display score here */
+			// TODO: MOVE TO JSON.Stringify ?
 			created_by_data_rules: `[${dataRules.toString(',')}]`
-		});
+		};
 	}
-	return planTags;
-}
+
+	return null;
+};
 
 
 

--- a/server/api/lib/tags/utils.js
+++ b/server/api/lib/tags/utils.js
@@ -1,24 +1,40 @@
 const PlanAreaChanges = require('../../../api/model/plan_area_changes');
-const { tagDataRules } = require('../../constants');
+const { tagDataRules, area_change_types } = require('../../constants');
 
 const isTagByUsageAddition = async (planId, rule) => {
 	try {
 		const result = await PlanAreaChanges.byPlanAndUsage(planId, rule.usage);
 		if (result && result.models && result.models[0]) {
 			const changeToApprovedState = result.models[0].attributes.change_to_approved_state;
-			if ( (changeToApprovedState.length > 1) && 
-				(changeToApprovedState.substring(0,1) === '+') ) {
-				const change = Number(changeToApprovedState.replace('+','').replace(',',''));
-				if (change >= Number(rule.minValue)) {
-					return {   
-						created_by_data_rules: `{rule:'${rule.description}',detail:'adds ${changeToApprovedState} ${rule.usage}'}`
-					}; 
+			const approvedState = result.models[0].attributes.approved_state;
+			switch (rule.changeType) {
+				case area_change_types.INCREASED_USAGE:
+					// change to approved state
+					if ((changeToApprovedState.length > 1) && 
+						(changeToApprovedState.substring(0,1) === '+') ) {
+						const change = Number(changeToApprovedState.replace('+','').replace(',',''));
+						if (change >= Number(rule.minValue)) {
+							return {   
+								created_by_data_rules: `{rule:'${rule.description}',detail:'adds ${changeToApprovedState} ${rule.usage}'}`
+							}; 
+						}
+					}					
+					break;	
+				case area_change_types.NEW_USAGE:
+					// new usage that was not approved previously
+					if ((changeToApprovedState.length > 1) && 
+					(changeToApprovedState.substring(0,1) === '+') && 
+					(approvedState === '')) {
+					const change = Number(changeToApprovedState.replace('+','').replace(',',''));
+					if (change >= Number(rule.minValue)) {
+						return {   
+							created_by_data_rules: `{rule:'${rule.description}',detail:'adds ${changeToApprovedState} ${rule.usage}'}`
+						}; 
+					}					
+					break;
 				}
-			}
-
+			}			
 		}		
-		
-	   
 	} catch (error) {
 		console.log(`error ${error.message}\n`);
 		console.debug(error);

--- a/server/api/lib/tags/utils.js
+++ b/server/api/lib/tags/utils.js
@@ -12,6 +12,7 @@ const isTagByUsageAddition = async (planId, rule) => {
 					// change to approved state
 					if ((changeToApprovedState.length > 1) && 
 						(changeToApprovedState.substring(0,1) === '+') ) {
+						// get change as number 
 						const change = Number(changeToApprovedState.replace('+','').replace(',',''));
 						if (change >= Number(rule.minValue)) {
 							return {   

--- a/server/api/lib/tags/utils.js
+++ b/server/api/lib/tags/utils.js
@@ -25,15 +25,27 @@ const isTagByUsageAddition = async (planId, rule) => {
 					if ((changeToApprovedState.length > 1) && 
 					(changeToApprovedState.substring(0,1) === '+') && 
 					(approvedState === '')) {
-					const change = Number(changeToApprovedState.replace('+','').replace(',',''));
-					if (change >= Number(rule.minValue)) {
-						return {   
-							created_by_data_rules: `{rule:'${rule.description}',detail:'adds ${changeToApprovedState} ${rule.usage}'}`
-						}; 
-					}					
+						const change = Number(changeToApprovedState.replace('+','').replace(',',''));
+						if (change >= Number(rule.minValue)) {
+							return {   
+								created_by_data_rules: `{rule:'${rule.description}',detail:'adds ${changeToApprovedState} ${rule.usage}'}`
+							}; 
+						}	
+					}
 					break;
-				}
-			}			
+				case area_change_types.PERCENT_INCREASE:
+						// usage that grows by a certain percentage
+						if ((changeToApprovedState.length > 1) && 
+						(changeToApprovedState.substring(0,1) === '+') && 
+						(approvedState !== '')) {
+							const change = Number(changeToApprovedState.replace('+','').replace(',',''));
+							if ((change+Number(approvedState))/Number(approvedState) >= (Number(rule.minValue)+100)/100.00) {
+								return {   
+									created_by_data_rules: `{rule:'${rule.description}',detail:'adds ${changeToApprovedState} ${rule.usage}'}`
+								}; 
+							}	
+						}
+						break;			}			
 		}		
 	} catch (error) {
 		console.log(`error ${error.message}\n`);

--- a/server/api/model/plan.js
+++ b/server/api/model/plan.js
@@ -486,7 +486,8 @@ class Plan extends Model {
 			}
 		}).fetchAll({
 			columns: [
-				'id'
+				'id',
+				'geom'
 			]
 		});
 	}	

--- a/server/api/model/plan_tag.js
+++ b/server/api/model/plan_tag.js
@@ -47,15 +47,15 @@ class PlanTag extends Model {
 	}
 
 	// TODO: change to get array of tags rather than just one
-	static async createPlanTags( data) {
+	static async createPlanTags(data) {
 		try {
 			await Bookshelf.transaction(async (transaction) => {
-				for (const datum in data ){
-					await new PlanTag(data[datum]).save(null, {transacting: transaction});
+				for (const datum in data) {
+					await new PlanTag(data[datum]).save(null, { transacting: transaction });
 			}
 		});
 		} catch (err) {
-			console.log(err);
+			Log.error(err);
 		}
 
 	}	

--- a/server/migrations/20171030203051_new_tables.js
+++ b/server/migrations/20171030203051_new_tables.js
@@ -17,7 +17,7 @@ exports.up = function(knex, Promise) {
           name: 'דיור',
         },
         {
-          name: 'תעסוקה ותעשיה',
+          name: 'תעסוקה',
         },
         {
           name: 'מבני ציבור',

--- a/server/migrations/20210615165314_add_tags.js
+++ b/server/migrations/20210615165314_add_tags.js
@@ -24,7 +24,7 @@ exports.up =	async function(knex)	{
 		.default(1);
 		table.string('created_by_data_rules');
 		table.boolean('created_by_child').default('false');
-		table.boolean('child_is_stand_alone').default('false');0
+		table.boolean('child_is_stand_alone').default('false');
 		table.datetime('creation_date').defaultTo(knex.fn.now());
 	 })	
 

--- a/server/migrations/20210825175016_init_tags_table.js
+++ b/server/migrations/20210825175016_init_tags_table.js
@@ -1,0 +1,43 @@
+const housingTag = require('../api/lib/tags/housing');
+const publicTag = require('../api/lib/tags/public');
+const hotelieryTag = require('../api/lib/tags/hoteliery');
+const commerceTag = require('../api/lib/tags/commerce');
+const employmentTag = require('../api/lib/tags/employment');
+
+exports.up = async function(knex) {
+
+    await knex.table('plan_tag').del();
+
+    await knex.raw('ALTER TABLE tag DROP FOREIGN KEY tag_parent_id_foreign');
+    await knex.raw('ALTER TABLE tag DROP COLUMN parent_id');
+
+    await knex.schema.table('tag', table => {
+        table.integer('parent_id')
+            .unsigned()
+            .references('id')
+            .inTable('tag')
+            .onDelete('set null');
+    });
+
+    const tbl = knex.table('tag');
+    // remove everything from the table
+    await tbl.del();
+
+    await tbl.insert({name: housingTag.TAG_NAME});
+    await tbl.insert({name: publicTag.TAG_NAME});
+	await tbl.insert({name: hotelieryTag.TAG_NAME});
+	await tbl.insert({name: commerceTag.TAG_NAME});
+	await tbl.insert({name: employmentTag.TAG_NAME});
+
+};
+
+exports.down = async function(knex) {
+    const tbl = knex.table('tag');
+
+    await tbl.where('name', housingTag.TAG_NAME).del();
+    await tbl.where('name', publicTag.TAG_NAME).del();
+	await tbl.where('name', hotelieryTag.TAG_NAME).del();
+	await tbl.where('name', commerceTag.TAG_NAME).del();
+	await tbl.where('name', employmentTag.TAG_NAME).del();
+    
+};

--- a/server/migrations/20210825175016_init_tags_table.js
+++ b/server/migrations/20210825175016_init_tags_table.js
@@ -6,25 +6,25 @@ const employmentTag = require('../api/lib/tags/employment');
 
 exports.up = async function(knex) {
 
-    await knex.table('plan_tag').del();
+	await knex.table('plan_tag').del();
 
-    await knex.raw('ALTER TABLE tag DROP FOREIGN KEY tag_parent_id_foreign');
-    await knex.raw('ALTER TABLE tag DROP COLUMN parent_id');
+	await knex.raw('ALTER TABLE tag DROP FOREIGN KEY tag_parent_id_foreign');
+	await knex.raw('ALTER TABLE tag DROP COLUMN parent_id');
 
-    await knex.schema.table('tag', table => {
-        table.integer('parent_id')
-            .unsigned()
-            .references('id')
-            .inTable('tag')
-            .onDelete('set null');
-    });
+	await knex.schema.table('tag', table => {
+		table.integer('parent_id')
+			.unsigned()
+			.references('id')
+			.inTable('tag')
+			.onDelete('set null');
+	});
 
-    const tbl = knex.table('tag');
-    // remove everything from the table
-    await tbl.del();
+	const tbl = knex.table('tag');
+	// remove everything from the table
+	await tbl.del();
 
-    await tbl.insert({name: housingTag.TAG_NAME});
-    await tbl.insert({name: publicTag.TAG_NAME});
+	await tbl.insert({name: housingTag.TAG_NAME});
+	await tbl.insert({name: publicTag.TAG_NAME});
 	await tbl.insert({name: hotelieryTag.TAG_NAME});
 	await tbl.insert({name: commerceTag.TAG_NAME});
 	await tbl.insert({name: employmentTag.TAG_NAME});
@@ -32,12 +32,12 @@ exports.up = async function(knex) {
 };
 
 exports.down = async function(knex) {
-    const tbl = knex.table('tag');
+	const tbl = knex.table('tag');
 
-    await tbl.where('name', housingTag.TAG_NAME).del();
-    await tbl.where('name', publicTag.TAG_NAME).del();
+	await tbl.where('name', housingTag.TAG_NAME).del();
+	await tbl.where('name', publicTag.TAG_NAME).del();
 	await tbl.where('name', hotelieryTag.TAG_NAME).del();
 	await tbl.where('name', commerceTag.TAG_NAME).del();
 	await tbl.where('name', employmentTag.TAG_NAME).del();
-    
+	
 };

--- a/server/migrations/20210825175016_init_tags_table.js
+++ b/server/migrations/20210825175016_init_tags_table.js
@@ -23,11 +23,11 @@ exports.up = async function(knex) {
 	// remove everything from the table
 	await tbl.del();
 
-	await tbl.insert({name: housingTag.TAG_NAME});
-	await tbl.insert({name: publicTag.TAG_NAME});
-	await tbl.insert({name: hotelieryTag.TAG_NAME});
-	await tbl.insert({name: commerceTag.TAG_NAME});
-	await tbl.insert({name: employmentTag.TAG_NAME});
+	await tbl.insert({name: housingTag.TAG_NAME, display_name: housingTag.TAG_DISPLAY_NAME});
+	await tbl.insert({name: publicTag.TAG_NAME, display_name: publicTag.TAG_DISPLAY_NAME});
+	await tbl.insert({name: hotelieryTag.TAG_NAME, display_name: hotelieryTag.TAG_DISPLAY_NAME});
+	await tbl.insert({name: commerceTag.TAG_NAME, display_name: commerceTag.TAG_DISPLAY_NAME});
+	await tbl.insert({name: employmentTag.TAG_NAME, display_name: employmentTag.TAG_DISPLAY_NAME});
 
 };
 

--- a/server/migrations/202108251814_add_additonal_tags.js
+++ b/server/migrations/202108251814_add_additonal_tags.js
@@ -1,0 +1,21 @@
+exports.up = async function(knex, Promise) {
+
+	await knex('tag').insert([
+			{
+			  name: 'מסחר',
+			},
+			{
+			  name:'תיירות'
+			}]);
+
+};
+
+exports.down = async function(knex, Promise) {
+	await knex('tag').delete([
+		{
+		  name: 'מסחר',
+		},
+		{
+		  name:'תיירות'
+		}]);
+};

--- a/server/tests/integration/process/tags.test.js
+++ b/server/tests/integration/process/tags.test.js
@@ -11,176 +11,297 @@ const planId = 1;
 const fakeUnitsAdded = 11;
 const fakeSqMrAdded = 1001;
 // Housing
+const HOUSING_TAG_NAME = 'דיור';
 const fakeHousingByUnitsTrue = { models: [{ attributes : { change_to_approved_state: `+${fakeUnitsAdded}` } }]} ;
 const fakeHousingByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${fakeSqMrAdded}` } }]} ;
-const HOUSING_BY_UNIT_RULE = tagDataRules.filter(tag => {return tag.tagName==='דיור'})[0].rules[1];
-const HOUSING_BY_AREA_RULE = tagDataRules.filter(tag => {return tag.tagName==='דיור'})[0].rules[0];
+const HOUSING_BY_UNIT_RULE = tagDataRules.filter(tag => {return tag.tagName===HOUSING_TAG_NAME})[0].rules.filter( rule => {return rule.usage==='מגורים (יח"ד)'})[0];
+const HOUSING_BY_AREA_RULE = tagDataRules.filter(tag => {return tag.tagName===HOUSING_TAG_NAME})[0].rules.filter( rule => {return rule.usage==='מגורים (מ"ר)'})[0];;  
 // Public Area
+const PUBLIC_TAG_NAME = 'מבני ציבור';
 const fakePublicByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${fakeSqMrAdded}` } }]} ;
-const PUBLIC_BY_AREA_RULE = tagDataRules.filter(tag => {return tag.tagName==='מבני ציבור'})[0].rules[0];;
+const PUBLIC_BY_AREA_RULE = tagDataRules.filter(tag => {return tag.tagName===PUBLIC_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
 // Employment Area
+const EMPLOYMENT_TAG_NAME = 'תעסוקה ותעשיה';
 const fakeEmploymentByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+1,500` } }]} ;
-const EMPLOYMWNT_BY_AREA_RULE_1 = tagDataRules.filter(tag => {return tag.tagName=== 'תעסוקה ותעשיה'})[0].rules[0];;
-const EMPLOYMWNT_BY_AREA_RULE_2 = tagDataRules.filter(tag => {return tag.tagName=== 'תעסוקה ותעשיה'})[0].rules[1];;
+const EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE = tagDataRules.filter(tag => {return tag.tagName=== EMPLOYMENT_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
+const EMPLOYMENT_BY_AREA_RULE_NEW_USAGE = tagDataRules.filter(tag => {return tag.tagName=== EMPLOYMENT_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.NEW_USAGE})[0];
+// Commerce Area
+const COMMERCE_TAG_NAME = 'מסחר';
+const COMMERCE_BY_AREA_RULE_INCREASED_USAGE = tagDataRules.filter(tag => {return tag.tagName=== COMMERCE_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
+const COMMERCE_BY_AREA_RULE_NEW_USAGE = tagDataRules.filter(tag => {return tag.tagName===COMMERCE_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.NEW_USAGE})[0];
+const COMMERCE_BY_AREA_RULE_PERCENT_INCREASE = tagDataRules.filter(tag => {return tag.tagName=== COMMERCE_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.PERCENT_INCREASE})[0];
+// Hoteliery Area
+const HOTELIERY_TAG_NAME = 'תיירות';
+const HOTELIERY_BY_AREA_RULE_INCREASED_USAGE = tagDataRules.filter(tag => {return tag.tagName=== HOTELIERY_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
+const HOTELIERY_BY_AREA_RULE_NEW_USAGE = tagDataRules.filter(tag => {return tag.tagName=== HOTELIERY_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.NEW_USAGE})[0];;
+const HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE = tagDataRules.filter(tag => {return tag.tagName=== HOTELIERY_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.PERCENT_INCREASE})[0];
+
+
 
 describe('Tags', function() {
-
-	describe('isTagByUsageAddition helper function - housing tag tests', function() { 
+	describe(`isTagByUsageAddition helper function`, function() { 
 		let myStub;
 		afterEach(async function() {
 			myStub.restore();
 			sinon.restore();
 		});
 
-		it('returns housing tag from isTagByUsageAddition for housingByUnits if database record is found & # of units exceeds minimum', async function() {
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByUnitsTrue);
-			const result =  await isTagByUsageAddition(planId,HOUSING_BY_UNIT_RULE); 
-			expect(result.created_by_data_rules).to.eql(`{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}`);
-			myStub.restore();			
+		describe(`"${HOUSING_TAG_NAME}" tag`, function() { 
+			it(`returns "${HOUSING_TAG_NAME}" tag for housingByUnits if database record is found & # of units exceeds minimum`, async function() {
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByUnitsTrue);
+				const result =  await isTagByUsageAddition(planId,HOUSING_BY_UNIT_RULE); 
+				expect(result.created_by_data_rules).to.eql(`{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}`);
+				myStub.restore();			
+			});
+
+			it(`does not return "${HOUSING_TAG_NAME}" tag for housingByUnits if number of units doesn\'t meet minimum`, async function() {
+				const fakeUnitsAddedTooSmall = 5;
+				const fakeHousingByUnitsTooSmall = { models: [{ attributes : { change_to_approved_state: `+${fakeUnitsAddedTooSmall}` } }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByUnitsTooSmall);
+				const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_UNIT_RULE); 
+				expect(result).to.eql(undefined);
+				myStub.restore();			
+			}); 
+			
+			it(`does not return "${HOUSING_TAG_NAME}" tag for housingByUnits if database record is not found`, async function() {
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(null);
+				const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_UNIT_RULE); 
+				expect(result).to.eql(undefined);
+				myStub.restore();			
+			});		   
+
+			it(`returns "${HOUSING_TAG_NAME}" tag for housingByArea if database record is found & area added is larger than minimum`, async function() {
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByAreaTrue);
+				const result =  await isTagByUsageAddition(planId,HOUSING_BY_AREA_RULE); 
+				expect(result.created_by_data_rules).to.eql(`{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'}`);
+			});	
+
+			it(`does not return "${HOUSING_TAG_NAME}" tag for housingByArea if area added doesn't meet minimum`, async function() {
+				const fakeAreaAddedTooSmall = 500;
+				const fakeHousingByAreaTooSmall = { models: [{ attributes : { change_to_approved_state: `+${fakeAreaAddedTooSmall}` } }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByAreaTooSmall);
+				const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_AREA_RULE); 
+				expect(result).to.eql(undefined);
+				myStub.restore();			
+			}); 
+			
+			it(`does not return "${HOUSING_TAG_NAME}" tag for housingByArea if database record is not found`, async function() {
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(null);
+				const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_AREA_RULE); 
+				expect(result).to.eql(undefined);
+				myStub.restore();			
+			});
 		});
 
-		it('does not return housing tag from isTagByUsageAddition for housingByUnits if number of units doesn\'t meet minimum', async function() {
-			const fakeUnitsAddedTooSmall = 5;
-			const fakeHousingByUnitsTooSmall = { models: [{ attributes : { change_to_approved_state: `+${fakeUnitsAddedTooSmall}` } }]} ;
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByUnitsTooSmall);
-			const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_UNIT_RULE); 
-			expect(result).to.eql(undefined);
-			myStub.restore();			
-		}); 
-		
-		it('does not return housing tag from isTagByUsageAddition for housingByUnits if database record is not found', async function() {
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(null);
-			const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_UNIT_RULE); 
-			expect(result).to.eql(undefined);
-			myStub.restore();			
-		});		   
+		describe(`"${PUBLIC_TAG_NAME}" tag`, function() { 
+			it(`returns "${PUBLIC_TAG_NAME}" tag if area added exceeds minimum`, async function() {
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakePublicByAreaTrue);
+				const result =  await isTagByUsageAddition(planId,PUBLIC_BY_AREA_RULE); 
+				expect(result.created_by_data_rules).to.eql(`{rule:'${PUBLIC_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} ${PUBLIC_BY_AREA_RULE.usage}'}`);
+				myStub.restore();			
+			});
+		});
 
-		it('returns housing tag from isTagByUsageAddition for housingByArea if database record is found & area added is larger than minimum', async function() {
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByAreaTrue);
-			const result =  await isTagByUsageAddition(planId,HOUSING_BY_AREA_RULE); 
-			expect(result.created_by_data_rules).to.eql(`{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'}`);
+		describe(`"${COMMERCE_TAG_NAME}" tag`, function() { 
+			it(`does not return "${COMMERCE_TAG_NAME}" tag if increased usage area is less than minimum`, async function() {
+				const addsSqMr = 99;
+				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'100'} }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
+				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_INCREASED_USAGE); 
+				expect(result).to.eql(undefined);
+				myStub.restore();			
+			});
+
+			it(`returns "${COMMERCE_TAG_NAME}" tag if increased usage exceeds minimum`, async function() {
+				const addsSqMr = 101;
+				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}`, approved_state:'100' } }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
+				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_INCREASED_USAGE); 
+				expect(result.created_by_data_rules).to.eql(`{rule:'${COMMERCE_BY_AREA_RULE_INCREASED_USAGE.description}',detail:'adds +${addsSqMr} ${COMMERCE_BY_AREA_RULE_INCREASED_USAGE.usage}'}`);
+				myStub.restore();			
+			});		
+
+			it(`does not return "${COMMERCE_TAG_NAME}" tag if brand new commerce area is less than 1'`, async function() {
+				const addsSqMr = 0;
+				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:''} }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
+				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_NEW_USAGE); 
+				expect(result).to.eql(undefined);
+				myStub.restore();			
+			});	
+			
+			it(`returns "${COMMERCE_TAG_NAME}" tag if area added exceeds minimum as new usage`, async function() {
+				const addsSqMr = 10;
+				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}`, approved_state:'' } }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
+				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_NEW_USAGE); 
+				expect(result.created_by_data_rules).to.eql(`{rule:'${COMMERCE_BY_AREA_RULE_NEW_USAGE.description}',detail:'adds +${addsSqMr} ${COMMERCE_BY_AREA_RULE_NEW_USAGE.usage}'}`);
+				myStub.restore();			
+			});			
+			
+			it(`does not return commerce tag if percent increase is less than 20%`, async function() {
+				const addsSqMr = 190;
+				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'1000'} }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
+				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_PERCENT_INCREASE); 
+				expect(result).to.eql(undefined);
+				myStub.restore();			
+			});		
+
+			it(`returns commerce tag if brand new commerce area is more than 20%`, async function() {
+				const addsSqMr = 100;
+				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'50'} }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
+				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_PERCENT_INCREASE); 
+				expect(result.created_by_data_rules).to.eql(`{rule:'${COMMERCE_BY_AREA_RULE_PERCENT_INCREASE.description}',detail:'adds +${addsSqMr} ${COMMERCE_BY_AREA_RULE_PERCENT_INCREASE.usage}'}`);
+				myStub.restore();			
+			});			
 		});	
 
-		it('does not return housing tag from isTagByUsageAddition for housingByArea if area added doesn\'t meet minimum', async function() {
-			const fakeAreaAddedTooSmall = 500;
-			const fakeHousingByAreaTooSmall = { models: [{ attributes : { change_to_approved_state: `+${fakeAreaAddedTooSmall}` } }]} ;
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByAreaTooSmall);
-			const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_AREA_RULE); 
-			expect(result).to.eql(undefined);
-			myStub.restore();			
-		}); 
-		
-		it('does not return housing tag from isTagByUsageAddition for housingByArea if database record is not found', async function() {
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(null);
-			const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_AREA_RULE); 
-			expect(result).to.eql(undefined);
-			myStub.restore();			
-		});		   
-		
-	});
+		describe(`"${HOTELIERY_TAG_NAME}" tag`, function() { 
+			it(`does not return "${HOTELIERY_TAG_NAME}" tag if increased usage area is less than minimum`, async function() {
+				const addsSqMr = 199;
+				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'100'} }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
+				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_INCREASED_USAGE); 
+				expect(result).to.eql(undefined);
+				myStub.restore();			
+			});
 
-	describe('isTagByUsageAddition helper function - public area tag tests', function() { 
-		let myStub;
-		afterEach(async function() {
-			myStub.restore();
-			sinon.restore();
-		});
+			it(`returns "${HOTELIERY_TAG_NAME}" tag if increased usage exceeds minimum`, async function() {
+				const addsSqMr = 201;
+				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}`, approved_state:'100' } }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
+				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_INCREASED_USAGE); 
+				expect(result.created_by_data_rules).to.eql(`{rule:'${HOTELIERY_BY_AREA_RULE_INCREASED_USAGE.description}',detail:'adds +${addsSqMr} ${HOTELIERY_BY_AREA_RULE_INCREASED_USAGE.usage}'}`);
+				myStub.restore();			
+			});		
 
+			it(`does not return "${HOTELIERY_TAG_NAME}" tag if brand new area is less than 1`, async function() {
+				const addsSqMr = 0;
+				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:''} }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
+				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_NEW_USAGE); 
+				expect(result).to.eql(undefined);
+				myStub.restore();			
+			});	
+			
+			it(`returns "${HOTELIERY_TAG_NAME}" tag if any brand new area added exceeds minimum`, async function() {
+				const addsSqMr = 10;
+				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}`, approved_state:'' } }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
+				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_NEW_USAGE); 
+				expect(result.created_by_data_rules).to.eql(`{rule:'${HOTELIERY_BY_AREA_RULE_NEW_USAGE.description}',detail:'adds +${addsSqMr} ${HOTELIERY_BY_AREA_RULE_NEW_USAGE.usage}'}`);
+				myStub.restore();			
+			});			
+			
+			it(`does not return "${HOTELIERY_TAG_NAME}" tag if percent increase is less than 30%`, async function() {
+				const addsSqMr = 29;
+				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'100'} }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
+				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE); 
+				expect(result).to.eql(undefined);
+				myStub.restore();			
+			});		
 
-		it('returns public tag from isTagByUsageAddition for public area if database record is found & area added exceeds minimum', async function() {
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakePublicByAreaTrue);
-			const result =  await isTagByUsageAddition(planId,PUBLIC_BY_AREA_RULE); 
-			expect(result.created_by_data_rules).to.eql(`{rule:'${PUBLIC_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} ${PUBLIC_BY_AREA_RULE.usage}'}`);
-			myStub.restore();			
-		});
-
-		
-	});
-
-	describe('isTagByUsageAddition helper function - EMPLOYMENT tag tests', function() { 
-		let myStub;
-		afterEach(async function() {
-			myStub.restore();
-			sinon.restore();
-		});
-
-
-		it('does not return public tag from isTagByUsageAddition for employment  if database record is found but area added is less than minimum', async function() {
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeEmploymentByAreaFalse);
-			const result =  await isTagByUsageAddition(planId,EMPLOYMWNT_BY_AREA_RULE_1); 
-			expect(result).to.eql(undefined);
-			myStub.restore();			
-		});
-
-		it('returns public tag from isTagByUsageAddition for employment if database record is found & area added exceeds minimum', async function() {
-			const addsSqMr = 2500;
-			const fakeEmploymentByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` } }]} ;
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeEmploymentByAreaTrue);
-			const result =  await isTagByUsageAddition(planId,EMPLOYMWNT_BY_AREA_RULE_1); 
-			expect(result.created_by_data_rules).to.eql(`{rule:'${EMPLOYMWNT_BY_AREA_RULE_1.description}',detail:'adds +${addsSqMr} ${EMPLOYMWNT_BY_AREA_RULE_1.usage}'}`);
-			myStub.restore();			
+			it(`returns" ${HOTELIERY_TAG_NAME}" tag if brand new area is more than 30%`, async function() {
+				const addsSqMr = 31;
+				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'100'} }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
+				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE); 
+				expect(result.created_by_data_rules).to.eql(`{rule:'${HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE.description}',detail:'adds +${addsSqMr} ${HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE.usage}'}`);
+				myStub.restore();			
+			});				
 		});		
 
-		it('returns public tag from isTagByUsageAddition for new employment if database record is found & area added exceeds minimum as new usage ', async function() {
-			const addsSqMr = 250;
-			const fakeEmploymentByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}`, approved_state:'' } }]} ;
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeEmploymentByAreaTrue);
-			const result =  await isTagByUsageAddition(planId,EMPLOYMWNT_BY_AREA_RULE_2); 
-			expect(result.created_by_data_rules).to.eql(`{rule:'${EMPLOYMWNT_BY_AREA_RULE_2.description}',detail:'adds +${addsSqMr} ${EMPLOYMWNT_BY_AREA_RULE_2.usage}'}`);
-			myStub.restore();			
-		});			
+		describe(`"${EMPLOYMENT_TAG_NAME}" tag`, function() { 
+			it(`does not return  "${EMPLOYMENT_TAG_NAME}" tag if area added is less than minimum`, async function() {
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeEmploymentByAreaFalse);
+				const result =  await isTagByUsageAddition(planId,EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE); 
+				expect(result).to.eql(undefined);
+				myStub.restore();			
+			});
 
-		
-	});	
+			it(`returns "${EMPLOYMENT_TAG_NAME}" tag if database record is found & area added exceeds minimum`, async function() {
+				const addsSqMr = 2500;
+				const fakeEmploymentByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` } }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeEmploymentByAreaTrue);
+				const result =  await isTagByUsageAddition(planId,EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE); 
+				expect(result.created_by_data_rules).to.eql(`{rule:'${EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE.description}',detail:'adds +${addsSqMr} ${EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE.usage}'}`);
+				myStub.restore();			
+			});		
 
+			it(`returns  "${EMPLOYMENT_TAG_NAME}" tag if database record is found & area added exceeds minimum as new usage `, async function() {
+				const addsSqMr = 250;
+				const fakeEmploymentByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}`, approved_state:'' } }]} ;
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeEmploymentByAreaTrue);
+				const result =  await isTagByUsageAddition(planId,EMPLOYMENT_BY_AREA_RULE_NEW_USAGE); 
+				expect(result.created_by_data_rules).to.eql(`{rule:'${EMPLOYMENT_BY_AREA_RULE_NEW_USAGE.description}',detail:'adds +${addsSqMr} ${EMPLOYMENT_BY_AREA_RULE_NEW_USAGE.usage}'}`);
+				myStub.restore();			
+			});			
+		});	
+	});
 
-
-	describe('doesTagApply - housing tag tests', function() { 
+	describe(`doesTagApply`, function() { 
 		let myStub;
 		afterEach(async function() {
 			myStub.restore();
 			sinon.restore();
 		});
 
-		it('returns the correct tag from doesTagApply when both housing by area and housing by units apply', async function() {
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
-			myStub.onCall(0).returns(fakeHousingByAreaTrue);
-			myStub.onCall(1).returns(fakeHousingByUnitsTrue);
-			const result =  await isHousing(planId); 
-			expect(result.length).to.eql(1);
-			expect(result[0].plan_id).to.eql(planId);
-			expect(result[0].tag_id).to.eql(housingTag);
-			expect(result[0].created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'},{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
+		describe(`"${HOUSING_TAG_NAME}" tag`, function() { 
+			it(`returns "${HOUSING_TAG_NAME}" tag when both housing by area and housing by units apply`, async function() {
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
+				myStub.onCall(0).returns(fakeHousingByAreaTrue);
+				myStub.onCall(1).returns(fakeHousingByUnitsTrue);
+				const result =  await isHousing(planId); 
+				expect(result.length).to.eql(1);
+				expect(result[0].plan_id).to.eql(planId);
+				expect(result[0].tag_id).to.eql(housingTag);
+				expect(result[0].created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'},{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
+			});
+
+			it(`returns "${HOUSING_TAG_NAME}" tag when only housing by units applies`, async function() {
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
+				myStub.onCall(0).returns(undefined);
+				myStub.onCall(1).returns(fakeHousingByUnitsTrue);
+				const result =  await isHousing(planId); 
+				expect(result.length).to.eql(1);
+				expect(result[0].plan_id).to.eql(planId);
+				expect(result[0].tag_id).to.eql(housingTag);
+				expect(result[0].created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
+			});		
+
+			it(`returns "${HOUSING_TAG_NAME}" tag when only housing by area applies`, async function() {
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
+				myStub.onCall(0).returns(fakeHousingByAreaTrue);
+				myStub.onCall(1).returns(null);
+				const result =  await isHousing(planId); 
+				expect(result.length).to.eql(1);
+				expect(result[0].plan_id).to.eql(planId);
+				expect(result[0].tag_id).to.eql(housingTag);
+				expect(result[0].created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'}]`);
+			});
+
+			it('returns no tags from doesTagApply when neither housing tag applies', async function() {
+				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
+				myStub.onCall(0).returns(undefined);
+				myStub.onCall(1).returns(undefined);
+				const result =  await isHousing(planId); 
+				expect(result.length).to.eql(0);
+			});		
 		});
 
-		it('returns the correct tag from doesTagApply when only housing by units applies', async function() {
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
-			myStub.onCall(0).returns(undefined);
-			myStub.onCall(1).returns(fakeHousingByUnitsTrue);
-			const result =  await isHousing(planId); 
-			expect(result.length).to.eql(1);
-			expect(result[0].plan_id).to.eql(planId);
-			expect(result[0].tag_id).to.eql(housingTag);
-			expect(result[0].created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
-		});		
-
-		it('returns the correct tag from doesTagApply when only housing by area applies', async function() {
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
-			myStub.onCall(0).returns(fakeHousingByAreaTrue);
-			myStub.onCall(1).returns(null);
-			const result =  await isHousing(planId); 
-			expect(result.length).to.eql(1);
-			expect(result[0].plan_id).to.eql(planId);
-			expect(result[0].tag_id).to.eql(housingTag);
-			expect(result[0].created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'}]`);
+		describe(`"${PUBLIC_TAG_NAME}" tag`, function() { 
 		});
 
-		it('returns no tags from doesTagApply when neither housing tag applies', async function() {
-			myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
-			myStub.onCall(0).returns(undefined);
-			myStub.onCall(1).returns(undefined);
-			const result =  await isHousing(planId); 
-			expect(result.length).to.eql(0);
+		describe(`"${EMPLOYMENT_TAG_NAME}" tag`, function() { 
+		});
+		
+		describe(`"${COMMERCE_TAG_NAME}" tag`, function() { 
+		});
+		
+		describe(`"${HOTELIERY_TAG_NAME}" tag`, function() { 
 		});		
 
 	});

--- a/server/tests/integration/process/tags/tags.test.js
+++ b/server/tests/integration/process/tags/tags.test.js
@@ -253,7 +253,7 @@ describe('Tags', function() {
 			tagNameToTagId['משהו_אקראי'] = 8;
 			tagNameToTagId[housingTagName] = CHECK_TAG_ID;
 
-			tagsResource = {
+			tagsResources = {
 				tagNameToTagId: tagNameToTagId
 			};
 		});

--- a/server/tests/integration/process/tags/tags.test.js
+++ b/server/tests/integration/process/tags/tags.test.js
@@ -268,7 +268,7 @@ describe('Tags', function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
 				myStub.onCall(0).returns(fakeHousingByAreaTrue);
 				myStub.onCall(1).returns(fakeHousingByUnitsTrue);
-				const result =  await isHousing(planId); 
+				const result =  await isHousing(planId,tagsResources); 
 				expect(result.plan_id).to.eql(planId);
 				expect(result.tag_id).to.eql(CHECK_TAG_ID);
 				expect(result.created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'},{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
@@ -278,7 +278,6 @@ describe('Tags', function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
 				myStub.onCall(0).returns(undefined);
 				myStub.onCall(1).returns(fakeHousingByUnitsTrue);
-				const result =  await isHousing(planId); 
 				expect(result.plan_id).to.eql(planId);
 				expect(result.tag_id).to.eql(CHECK_TAG_ID);
 				expect(result.created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
@@ -288,7 +287,7 @@ describe('Tags', function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
 				myStub.onCall(0).returns(fakeHousingByAreaTrue);
 				myStub.onCall(1).returns(null);
-				const result =  await isHousing(planId); 
+				const result =  await isHousing(planId,tagsResources); 
 				expect(result.plan_id).to.eql(planId);
 				expect(result.tag_id).to.eql(CHECK_TAG_ID);
 				expect(result.created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'}]`);
@@ -298,7 +297,7 @@ describe('Tags', function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
 				myStub.onCall(0).returns(undefined);
 				myStub.onCall(1).returns(undefined);
-				const result =  await isHousing(planId); 
+				const result =  await isHousing(planId,tagsResources); 
 				expect(result).to.eql(null);
 			});		
 		});

--- a/server/tests/integration/process/tags/tags.test.js
+++ b/server/tests/integration/process/tags/tags.test.js
@@ -245,7 +245,7 @@ describe('Tags', function() {
 	describe(`doesTagApply`, function() { 
 		const CHECK_TAG_ID = 9;
 		let myStub;
-		let tagsResource;
+		let tagsResources;
 
 		before(function() {
 

--- a/server/tests/integration/process/tags/tags.test.js
+++ b/server/tests/integration/process/tags/tags.test.js
@@ -2,12 +2,12 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const { isTagByUsageAddition } = require('../../../api/lib/tags/utils');
 const { tagDataRules, area_change_types } = require('../../../api/constants');
-const { doesTagApply: isHousing } = require('./../../../api/lib/tags/housing');
+const { doesTagApply: isHousing, TAG_NAME: housingTagName  } = require('./../../../api/lib/tags/housing');
 const PlanAreaChanges = require('../../../api/model/plan_area_changes');
 
 
-const housingTag = 1;
-const planId = 1; 
+const planId = 1;
+const plan = {id: planId};
 const fakeUnitsAdded = 11;
 const fakeSqMrAdded = 1001;
 // Housing
@@ -49,7 +49,7 @@ describe('Tags', function() {
 		describe(`"${HOUSING_TAG_NAME}" tag`, function() { 
 			it(`returns "${HOUSING_TAG_NAME}" tag for housingByUnits if database record is found & # of units exceeds minimum`, async function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByUnitsTrue);
-				const result =  await isTagByUsageAddition(planId,HOUSING_BY_UNIT_RULE); 
+				const result =  await isTagByUsageAddition(plan,HOUSING_BY_UNIT_RULE); 
 				expect(result.created_by_data_rules).to.eql(`{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}`);
 				myStub.restore();			
 			});
@@ -58,21 +58,21 @@ describe('Tags', function() {
 				const fakeUnitsAddedTooSmall = 5;
 				const fakeHousingByUnitsTooSmall = { models: [{ attributes : { change_to_approved_state: `+${fakeUnitsAddedTooSmall}` } }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByUnitsTooSmall);
-				const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_UNIT_RULE); 
+				const result =  await isTagByUsageAddition(plan,housingTag,HOUSING_BY_UNIT_RULE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			}); 
 			
 			it(`does not return "${HOUSING_TAG_NAME}" tag for housingByUnits if database record is not found`, async function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(null);
-				const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_UNIT_RULE); 
+				const result =  await isTagByUsageAddition(plan,housingTag,HOUSING_BY_UNIT_RULE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			});		   
 
 			it(`returns "${HOUSING_TAG_NAME}" tag for housingByArea if database record is found & area added is larger than minimum`, async function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByAreaTrue);
-				const result =  await isTagByUsageAddition(planId,HOUSING_BY_AREA_RULE); 
+				const result =  await isTagByUsageAddition(plan,HOUSING_BY_AREA_RULE); 
 				expect(result.created_by_data_rules).to.eql(`{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'}`);
 			});	
 
@@ -80,14 +80,14 @@ describe('Tags', function() {
 				const fakeAreaAddedTooSmall = 500;
 				const fakeHousingByAreaTooSmall = { models: [{ attributes : { change_to_approved_state: `+${fakeAreaAddedTooSmall}` } }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByAreaTooSmall);
-				const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_AREA_RULE); 
+				const result =  await isTagByUsageAddition(plan,housingTag,HOUSING_BY_AREA_RULE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			}); 
 			
 			it(`does not return "${HOUSING_TAG_NAME}" tag for housingByArea if database record is not found`, async function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(null);
-				const result =  await isTagByUsageAddition(planId,housingTag,HOUSING_BY_AREA_RULE); 
+				const result =  await isTagByUsageAddition(plan,housingTag,HOUSING_BY_AREA_RULE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			});
@@ -96,7 +96,7 @@ describe('Tags', function() {
 		describe(`"${PUBLIC_TAG_NAME}" tag`, function() { 
 			it(`returns "${PUBLIC_TAG_NAME}" tag if area added exceeds minimum`, async function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakePublicByAreaTrue);
-				const result =  await isTagByUsageAddition(planId,PUBLIC_BY_AREA_RULE); 
+				const result =  await isTagByUsageAddition(plan,PUBLIC_BY_AREA_RULE); 
 				expect(result.created_by_data_rules).to.eql(`{rule:'${PUBLIC_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} ${PUBLIC_BY_AREA_RULE.usage}'}`);
 				myStub.restore();			
 			});
@@ -107,7 +107,7 @@ describe('Tags', function() {
 				const addsSqMr = 99;
 				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'100'} }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
-				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_INCREASED_USAGE); 
+				const result =  await isTagByUsageAddition(plan,COMMERCE_BY_AREA_RULE_INCREASED_USAGE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			});
@@ -116,7 +116,7 @@ describe('Tags', function() {
 				const addsSqMr = 101;
 				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}`, approved_state:'100' } }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
-				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_INCREASED_USAGE); 
+				const result =  await isTagByUsageAddition(plan,COMMERCE_BY_AREA_RULE_INCREASED_USAGE); 
 				expect(result.created_by_data_rules).to.eql(`{rule:'${COMMERCE_BY_AREA_RULE_INCREASED_USAGE.description}',detail:'adds +${addsSqMr} ${COMMERCE_BY_AREA_RULE_INCREASED_USAGE.usage}'}`);
 				myStub.restore();			
 			});		
@@ -125,7 +125,7 @@ describe('Tags', function() {
 				const addsSqMr = 0;
 				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:''} }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
-				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_NEW_USAGE); 
+				const result =  await isTagByUsageAddition(plan,COMMERCE_BY_AREA_RULE_NEW_USAGE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			});	
@@ -134,7 +134,7 @@ describe('Tags', function() {
 				const addsSqMr = 10;
 				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}`, approved_state:'' } }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
-				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_NEW_USAGE); 
+				const result =  await isTagByUsageAddition(plan,COMMERCE_BY_AREA_RULE_NEW_USAGE); 
 				expect(result.created_by_data_rules).to.eql(`{rule:'${COMMERCE_BY_AREA_RULE_NEW_USAGE.description}',detail:'adds +${addsSqMr} ${COMMERCE_BY_AREA_RULE_NEW_USAGE.usage}'}`);
 				myStub.restore();			
 			});			
@@ -143,7 +143,7 @@ describe('Tags', function() {
 				const addsSqMr = 190;
 				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'1000'} }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
-				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_PERCENT_INCREASE); 
+				const result =  await isTagByUsageAddition(plan,COMMERCE_BY_AREA_RULE_PERCENT_INCREASE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			});		
@@ -152,7 +152,7 @@ describe('Tags', function() {
 				const addsSqMr = 100;
 				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'50'} }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
-				const result =  await isTagByUsageAddition(planId,COMMERCE_BY_AREA_RULE_PERCENT_INCREASE); 
+				const result =  await isTagByUsageAddition(plan,COMMERCE_BY_AREA_RULE_PERCENT_INCREASE); 
 				expect(result.created_by_data_rules).to.eql(`{rule:'${COMMERCE_BY_AREA_RULE_PERCENT_INCREASE.description}',detail:'adds +${addsSqMr} ${COMMERCE_BY_AREA_RULE_PERCENT_INCREASE.usage}'}`);
 				myStub.restore();			
 			});			
@@ -163,7 +163,7 @@ describe('Tags', function() {
 				const addsSqMr = 199;
 				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'100'} }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
-				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_INCREASED_USAGE); 
+				const result =  await isTagByUsageAddition(plan,HOTELIERY_BY_AREA_RULE_INCREASED_USAGE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			});
@@ -172,7 +172,7 @@ describe('Tags', function() {
 				const addsSqMr = 201;
 				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}`, approved_state:'100' } }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
-				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_INCREASED_USAGE); 
+				const result =  await isTagByUsageAddition(plan,HOTELIERY_BY_AREA_RULE_INCREASED_USAGE); 
 				expect(result.created_by_data_rules).to.eql(`{rule:'${HOTELIERY_BY_AREA_RULE_INCREASED_USAGE.description}',detail:'adds +${addsSqMr} ${HOTELIERY_BY_AREA_RULE_INCREASED_USAGE.usage}'}`);
 				myStub.restore();			
 			});		
@@ -181,7 +181,7 @@ describe('Tags', function() {
 				const addsSqMr = 0;
 				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:''} }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
-				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_NEW_USAGE); 
+				const result =  await isTagByUsageAddition(plan,HOTELIERY_BY_AREA_RULE_NEW_USAGE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			});	
@@ -190,7 +190,7 @@ describe('Tags', function() {
 				const addsSqMr = 10;
 				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}`, approved_state:'' } }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
-				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_NEW_USAGE); 
+				const result =  await isTagByUsageAddition(plan,HOTELIERY_BY_AREA_RULE_NEW_USAGE); 
 				expect(result.created_by_data_rules).to.eql(`{rule:'${HOTELIERY_BY_AREA_RULE_NEW_USAGE.description}',detail:'adds +${addsSqMr} ${HOTELIERY_BY_AREA_RULE_NEW_USAGE.usage}'}`);
 				myStub.restore();			
 			});			
@@ -199,7 +199,7 @@ describe('Tags', function() {
 				const addsSqMr = 29;
 				const fakeByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'100'} }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaFalse);
-				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE); 
+				const result =  await isTagByUsageAddition(plan,HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			});		
@@ -208,7 +208,7 @@ describe('Tags', function() {
 				const addsSqMr = 31;
 				const fakeByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` , approved_state:'100'} }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeByAreaTrue);
-				const result =  await isTagByUsageAddition(planId,HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE); 
+				const result =  await isTagByUsageAddition(plan,HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE); 
 				expect(result.created_by_data_rules).to.eql(`{rule:'${HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE.description}',detail:'adds +${addsSqMr} ${HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE.usage}'}`);
 				myStub.restore();			
 			});				
@@ -217,7 +217,7 @@ describe('Tags', function() {
 		describe(`"${EMPLOYMENT_TAG_NAME}" tag`, function() { 
 			it(`does not return  "${EMPLOYMENT_TAG_NAME}" tag if area added is less than minimum`, async function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeEmploymentByAreaFalse);
-				const result =  await isTagByUsageAddition(planId,EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE); 
+				const result =  await isTagByUsageAddition(plan,EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			});
@@ -226,7 +226,7 @@ describe('Tags', function() {
 				const addsSqMr = 2500;
 				const fakeEmploymentByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}` } }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeEmploymentByAreaTrue);
-				const result =  await isTagByUsageAddition(planId,EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE); 
+				const result =  await isTagByUsageAddition(plan,EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE); 
 				expect(result.created_by_data_rules).to.eql(`{rule:'${EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE.description}',detail:'adds +${addsSqMr} ${EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE.usage}'}`);
 				myStub.restore();			
 			});		
@@ -235,7 +235,7 @@ describe('Tags', function() {
 				const addsSqMr = 250;
 				const fakeEmploymentByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${addsSqMr}`, approved_state:'' } }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeEmploymentByAreaTrue);
-				const result =  await isTagByUsageAddition(planId,EMPLOYMENT_BY_AREA_RULE_NEW_USAGE); 
+				const result =  await isTagByUsageAddition(plan,EMPLOYMENT_BY_AREA_RULE_NEW_USAGE); 
 				expect(result.created_by_data_rules).to.eql(`{rule:'${EMPLOYMENT_BY_AREA_RULE_NEW_USAGE.description}',detail:'adds +${addsSqMr} ${EMPLOYMENT_BY_AREA_RULE_NEW_USAGE.usage}'}`);
 				myStub.restore();			
 			});			
@@ -243,7 +243,21 @@ describe('Tags', function() {
 	});
 
 	describe(`doesTagApply`, function() { 
+		const CHECK_TAG_ID = 9;
 		let myStub;
+		let tagsResource;
+
+		before(function() {
+
+			const tagNameToTagId = {};
+			tagNameToTagId['משהו_אקראי'] = 8;
+			tagNameToTagId[housingTagName] = CHECK_TAG_ID;
+
+			tagsResource = {
+				tagNameToTagId: tagNameToTagId
+			};
+		});
+
 		afterEach(async function() {
 			myStub.restore();
 			sinon.restore();
@@ -255,10 +269,9 @@ describe('Tags', function() {
 				myStub.onCall(0).returns(fakeHousingByAreaTrue);
 				myStub.onCall(1).returns(fakeHousingByUnitsTrue);
 				const result =  await isHousing(planId); 
-				expect(result.length).to.eql(1);
-				expect(result[0].plan_id).to.eql(planId);
-				expect(result[0].tag_id).to.eql(housingTag);
-				expect(result[0].created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'},{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
+				expect(result.plan_id).to.eql(planId);
+				expect(result.tag_id).to.eql(housingTag);
+				expect(result.created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'},{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
 			});
 
 			it(`returns "${HOUSING_TAG_NAME}" tag when only housing by units applies`, async function() {
@@ -266,10 +279,9 @@ describe('Tags', function() {
 				myStub.onCall(0).returns(undefined);
 				myStub.onCall(1).returns(fakeHousingByUnitsTrue);
 				const result =  await isHousing(planId); 
-				expect(result.length).to.eql(1);
-				expect(result[0].plan_id).to.eql(planId);
-				expect(result[0].tag_id).to.eql(housingTag);
-				expect(result[0].created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
+				expect(result.plan_id).to.eql(planId);
+				expect(result.tag_id).to.eql(housingTag);
+				expect(result.created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
 			});		
 
 			it(`returns "${HOUSING_TAG_NAME}" tag when only housing by area applies`, async function() {
@@ -277,10 +289,9 @@ describe('Tags', function() {
 				myStub.onCall(0).returns(fakeHousingByAreaTrue);
 				myStub.onCall(1).returns(null);
 				const result =  await isHousing(planId); 
-				expect(result.length).to.eql(1);
-				expect(result[0].plan_id).to.eql(planId);
-				expect(result[0].tag_id).to.eql(housingTag);
-				expect(result[0].created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'}]`);
+				expect(result.plan_id).to.eql(planId);
+				expect(result.tag_id).to.eql(housingTag);
+				expect(result.created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'}]`);
 			});
 
 			it('returns no tags from doesTagApply when neither housing tag applies', async function() {
@@ -288,7 +299,7 @@ describe('Tags', function() {
 				myStub.onCall(0).returns(undefined);
 				myStub.onCall(1).returns(undefined);
 				const result =  await isHousing(planId); 
-				expect(result.length).to.eql(0);
+				expect(result).to.eql(null);
 			});		
 		});
 

--- a/server/tests/integration/process/tags/tags.test.js
+++ b/server/tests/integration/process/tags/tags.test.js
@@ -278,6 +278,7 @@ describe('Tags', function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage');
 				myStub.onCall(0).returns(undefined);
 				myStub.onCall(1).returns(fakeHousingByUnitsTrue);
+				const result =  await isHousing(planId,tagsResources); 
 				expect(result.plan_id).to.eql(planId);
 				expect(result.tag_id).to.eql(CHECK_TAG_ID);
 				expect(result.created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);

--- a/server/tests/integration/process/tags/tags.test.js
+++ b/server/tests/integration/process/tags/tags.test.js
@@ -21,7 +21,7 @@ const PUBLIC_TAG_NAME = 'מבני ציבור';
 const fakePublicByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${fakeSqMrAdded}` } }]} ;
 const PUBLIC_BY_AREA_RULE = tagDataRules.filter(tag => {return tag.tagName===PUBLIC_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
 // Employment Area
-const EMPLOYMENT_TAG_NAME = 'תעסוקה ';
+const EMPLOYMENT_TAG_NAME = 'תעסוקה';
 const fakeEmploymentByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+1,500` } }]} ;
 const EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE = tagDataRules.filter(tag => {return tag.tagName=== EMPLOYMENT_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
 const EMPLOYMENT_BY_AREA_RULE_NEW_USAGE = tagDataRules.filter(tag => {return tag.tagName=== EMPLOYMENT_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.NEW_USAGE})[0];

--- a/server/tests/integration/process/tags/tags.test.js
+++ b/server/tests/integration/process/tags/tags.test.js
@@ -21,7 +21,7 @@ const PUBLIC_TAG_NAME = 'מבני ציבור';
 const fakePublicByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${fakeSqMrAdded}` } }]} ;
 const PUBLIC_BY_AREA_RULE = tagDataRules.filter(tag => {return tag.tagName===PUBLIC_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
 // Employment Area
-const EMPLOYMENT_TAG_NAME = 'תעסוקה ותעשיה';
+const EMPLOYMENT_TAG_NAME = 'תעסוקה ';
 const fakeEmploymentByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+1,500` } }]} ;
 const EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE = tagDataRules.filter(tag => {return tag.tagName=== EMPLOYMENT_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
 const EMPLOYMENT_BY_AREA_RULE_NEW_USAGE = tagDataRules.filter(tag => {return tag.tagName=== EMPLOYMENT_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.NEW_USAGE})[0];

--- a/server/tests/integration/process/tags/tags.test.js
+++ b/server/tests/integration/process/tags/tags.test.js
@@ -1,9 +1,9 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
-const { isTagByUsageAddition } = require('../../../api/lib/tags/utils');
-const { tagDataRules, area_change_types } = require('../../../api/constants');
-const { doesTagApply: isHousing, TAG_NAME: housingTagName  } = require('./../../../api/lib/tags/housing');
-const PlanAreaChanges = require('../../../api/model/plan_area_changes');
+const { isTagByUsageAddition } = require('../../../../api/lib/tags/utils');
+const { tagDataRules, area_change_types } = require('../../../../api/constants');
+const { doesTagApply: isHousing, TAG_NAME: housingTagName  } = require('../../../../api/lib/tags/housing');
+const PlanAreaChanges = require('../../../../api/model/plan_area_changes');
 
 
 const planId = 1;

--- a/server/tests/integration/process/tags/tags.test.js
+++ b/server/tests/integration/process/tags/tags.test.js
@@ -1,8 +1,12 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const { isTagByUsageAddition } = require('../../../../api/lib/tags/utils');
-const { tagDataRules, area_change_types } = require('../../../../api/constants');
-const { doesTagApply: isHousing, TAG_NAME: housingTagName  } = require('../../../../api/lib/tags/housing');
+const { tagDataRules, AREA_CHANGE_TYPES } = require('../../../../api/constants');
+const { doesTagApply: isHousing, TAG_NAME: HOUSING_TAG_NAME  } = require('../../../../api/lib/tags/housing');
+const { TAG_NAME: PUBLIC_TAG_NAME  } = require('../../../../api/lib/tags/public');
+const { TAG_NAME: EMPLOYMENT_TAG_NAME  } = require('../../../../api/lib/tags/employment');
+const { TAG_NAME: COMMERCE_TAG_NAME  } = require('../../../../api/lib/tags/commerce');
+const { TAG_NAME: HOTELIERY_TAG_NAME  } = require('../../../../api/lib/tags/hoteliery');
 const PlanAreaChanges = require('../../../../api/model/plan_area_changes');
 
 
@@ -11,30 +15,26 @@ const plan = {id: planId};
 const fakeUnitsAdded = 11;
 const fakeSqMrAdded = 1001;
 // Housing
-const HOUSING_TAG_NAME = 'דיור';
+
 const fakeHousingByUnitsTrue = { models: [{ attributes : { change_to_approved_state: `+${fakeUnitsAdded}` } }]} ;
 const fakeHousingByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${fakeSqMrAdded}` } }]} ;
 const HOUSING_BY_UNIT_RULE = tagDataRules.filter(tag => {return tag.tagName===HOUSING_TAG_NAME})[0].rules.filter( rule => {return rule.usage==='מגורים (יח"ד)'})[0];
 const HOUSING_BY_AREA_RULE = tagDataRules.filter(tag => {return tag.tagName===HOUSING_TAG_NAME})[0].rules.filter( rule => {return rule.usage==='מגורים (מ"ר)'})[0];;  
 // Public Area
-const PUBLIC_TAG_NAME = 'מבני ציבור';
 const fakePublicByAreaTrue = { models: [{ attributes : { change_to_approved_state: `+${fakeSqMrAdded}` } }]} ;
-const PUBLIC_BY_AREA_RULE = tagDataRules.filter(tag => {return tag.tagName===PUBLIC_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
+const PUBLIC_BY_AREA_RULE = tagDataRules.filter(tag => {return tag.tagName===PUBLIC_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===AREA_CHANGE_TYPES.INCREASED_USAGE})[0];
 // Employment Area
-const EMPLOYMENT_TAG_NAME = 'תעסוקה';
 const fakeEmploymentByAreaFalse = { models: [{ attributes : { change_to_approved_state: `+1,500` } }]} ;
-const EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE = tagDataRules.filter(tag => {return tag.tagName=== EMPLOYMENT_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
-const EMPLOYMENT_BY_AREA_RULE_NEW_USAGE = tagDataRules.filter(tag => {return tag.tagName=== EMPLOYMENT_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.NEW_USAGE})[0];
+const EMPLOYMENT_BY_AREA_RULE_INCREASED_USAGE = tagDataRules.filter(tag => {return tag.tagName=== EMPLOYMENT_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===AREA_CHANGE_TYPES.INCREASED_USAGE})[0];
+const EMPLOYMENT_BY_AREA_RULE_NEW_USAGE = tagDataRules.filter(tag => {return tag.tagName=== EMPLOYMENT_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===AREA_CHANGE_TYPES.NEW_USAGE})[0];
 // Commerce Area
-const COMMERCE_TAG_NAME = 'מסחר';
-const COMMERCE_BY_AREA_RULE_INCREASED_USAGE = tagDataRules.filter(tag => {return tag.tagName=== COMMERCE_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
-const COMMERCE_BY_AREA_RULE_NEW_USAGE = tagDataRules.filter(tag => {return tag.tagName===COMMERCE_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.NEW_USAGE})[0];
-const COMMERCE_BY_AREA_RULE_PERCENT_INCREASE = tagDataRules.filter(tag => {return tag.tagName=== COMMERCE_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.PERCENT_INCREASE})[0];
+const COMMERCE_BY_AREA_RULE_INCREASED_USAGE = tagDataRules.filter(tag => {return tag.tagName=== COMMERCE_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===AREA_CHANGE_TYPES.INCREASED_USAGE})[0];
+const COMMERCE_BY_AREA_RULE_NEW_USAGE = tagDataRules.filter(tag => {return tag.tagName===COMMERCE_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===AREA_CHANGE_TYPES.NEW_USAGE})[0];
+const COMMERCE_BY_AREA_RULE_PERCENT_INCREASE = tagDataRules.filter(tag => {return tag.tagName=== COMMERCE_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===AREA_CHANGE_TYPES.PERCENT_INCREASE})[0];
 // Hoteliery Area
-const HOTELIERY_TAG_NAME = 'תיירות';
-const HOTELIERY_BY_AREA_RULE_INCREASED_USAGE = tagDataRules.filter(tag => {return tag.tagName=== HOTELIERY_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.INCREASED_USAGE})[0];
-const HOTELIERY_BY_AREA_RULE_NEW_USAGE = tagDataRules.filter(tag => {return tag.tagName=== HOTELIERY_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.NEW_USAGE})[0];;
-const HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE = tagDataRules.filter(tag => {return tag.tagName=== HOTELIERY_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===area_change_types.PERCENT_INCREASE})[0];
+const HOTELIERY_BY_AREA_RULE_INCREASED_USAGE = tagDataRules.filter(tag => {return tag.tagName=== HOTELIERY_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===AREA_CHANGE_TYPES.INCREASED_USAGE})[0];
+const HOTELIERY_BY_AREA_RULE_NEW_USAGE = tagDataRules.filter(tag => {return tag.tagName=== HOTELIERY_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===AREA_CHANGE_TYPES.NEW_USAGE})[0];;
+const HOTELIERY_BY_AREA_RULE_PERCENT_INCREASE = tagDataRules.filter(tag => {return tag.tagName=== HOTELIERY_TAG_NAME})[0].rules.filter( rule => {return rule.changeType===AREA_CHANGE_TYPES.PERCENT_INCREASE})[0];
 
 
 
@@ -251,7 +251,7 @@ describe('Tags', function() {
 
 			const tagNameToTagId = {};
 			tagNameToTagId['משהו_אקראי'] = 8;
-			tagNameToTagId[housingTagName] = CHECK_TAG_ID;
+			tagNameToTagId[HOUSING_TAG_NAME] = CHECK_TAG_ID;
 
 			tagsResources = {
 				tagNameToTagId: tagNameToTagId

--- a/server/tests/integration/process/tags/tags.test.js
+++ b/server/tests/integration/process/tags/tags.test.js
@@ -58,14 +58,14 @@ describe('Tags', function() {
 				const fakeUnitsAddedTooSmall = 5;
 				const fakeHousingByUnitsTooSmall = { models: [{ attributes : { change_to_approved_state: `+${fakeUnitsAddedTooSmall}` } }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByUnitsTooSmall);
-				const result =  await isTagByUsageAddition(plan,housingTag,HOUSING_BY_UNIT_RULE); 
+				const result =  await isTagByUsageAddition(plan,HOUSING_BY_UNIT_RULE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			}); 
 			
 			it(`does not return "${HOUSING_TAG_NAME}" tag for housingByUnits if database record is not found`, async function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(null);
-				const result =  await isTagByUsageAddition(plan,housingTag,HOUSING_BY_UNIT_RULE); 
+				const result =  await isTagByUsageAddition(plan,HOUSING_BY_UNIT_RULE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			});		   
@@ -80,14 +80,14 @@ describe('Tags', function() {
 				const fakeAreaAddedTooSmall = 500;
 				const fakeHousingByAreaTooSmall = { models: [{ attributes : { change_to_approved_state: `+${fakeAreaAddedTooSmall}` } }]} ;
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(fakeHousingByAreaTooSmall);
-				const result =  await isTagByUsageAddition(plan,housingTag,HOUSING_BY_AREA_RULE); 
+				const result =  await isTagByUsageAddition(plan,HOUSING_BY_AREA_RULE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			}); 
 			
 			it(`does not return "${HOUSING_TAG_NAME}" tag for housingByArea if database record is not found`, async function() {
 				myStub = sinon.stub(PlanAreaChanges,'byPlanAndUsage').returns(null);
-				const result =  await isTagByUsageAddition(plan,housingTag,HOUSING_BY_AREA_RULE); 
+				const result =  await isTagByUsageAddition(plan,HOUSING_BY_AREA_RULE); 
 				expect(result).to.eql(undefined);
 				myStub.restore();			
 			});
@@ -270,7 +270,7 @@ describe('Tags', function() {
 				myStub.onCall(1).returns(fakeHousingByUnitsTrue);
 				const result =  await isHousing(planId); 
 				expect(result.plan_id).to.eql(planId);
-				expect(result.tag_id).to.eql(housingTag);
+				expect(result.tag_id).to.eql(CHECK_TAG_ID);
 				expect(result.created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'},{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
 			});
 
@@ -280,7 +280,7 @@ describe('Tags', function() {
 				myStub.onCall(1).returns(fakeHousingByUnitsTrue);
 				const result =  await isHousing(planId); 
 				expect(result.plan_id).to.eql(planId);
-				expect(result.tag_id).to.eql(housingTag);
+				expect(result.tag_id).to.eql(CHECK_TAG_ID);
 				expect(result.created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_UNIT_RULE.description}',detail:'adds +${fakeUnitsAdded} מגורים (יח"ד)'}]`);
 			});		
 
@@ -290,7 +290,7 @@ describe('Tags', function() {
 				myStub.onCall(1).returns(null);
 				const result =  await isHousing(planId); 
 				expect(result.plan_id).to.eql(planId);
-				expect(result.tag_id).to.eql(housingTag);
+				expect(result.tag_id).to.eql(CHECK_TAG_ID);
 				expect(result.created_by_data_rules).to.eql( `[{rule:'${HOUSING_BY_AREA_RULE.description}',detail:'adds +${fakeSqMrAdded} מגורים (מ"ר)'}]`);
 			});
 

--- a/server/tests/tables_structs/index.js
+++ b/server/tests/tables_structs/index.js
@@ -13,3 +13,4 @@ exports.plan_person = require('./plan_person_struct');
 exports.funding_transaction = require('./funding_transaction_struct');
 exports.file = require('./file_struct');
 exports.plan_area_changes = require('./plan_area_changes_struct');
+exports.tag = require('./tag_struct');

--- a/server/tests/tables_structs/tag_struct.js
+++ b/server/tests/tables_structs/tag_struct.js
@@ -1,0 +1,16 @@
+const TagStruct = function(table) {
+    table.increments('id').primary();
+    table.string('name');
+    table.integer('parent_id')
+        .unsigned()
+        .references('id')
+        .inTable('tag');
+    table.string('display_name');
+    table.integer('score');
+    table.boolean('is_super_tag');
+    table.boolean('is_stand_alone');
+    table.string('display_tooltip');
+    return table;
+};
+
+module.exports = TagStruct;


### PR DESCRIPTION
continued work towards issue #394 

This PR:
- [x] Implements 3 new tags (employment, hoteliery & commerce tags)
- [x] Adds two new types of plan area changes to check for (new area and percent increase)
- [x] Incorporates architecture changes from @TomerMe2 's WIP branch in #422 