### PR TITLE
updatePlanTags In Crawler Can Be Called From A Cron Job 

### DIFF
--- a/server/api/controller/cron.js
+++ b/server/api/controller/cron.js
@@ -307,7 +307,6 @@ const updatePlanTags = async () => {
 	// Re-compute the tags of a plan if the last update time of the plan is after the last update time of the tags of this plan.
 	// Before re-computing the tags of a plan, remove all previous tags for this plan.
 
-	// TODO: Loop on the plans that need to be updated
 	const plans = await Plan.getPlansToTag();
 	Log.info(`Processing ${plans.models.length} plans`);
 	for (const planOrder in plans.models) {
@@ -323,10 +322,13 @@ const updatePlanTags = async () => {
 		}
 
 		const tags = await tagger(plan);
-		if (tags && tags.length > 0){
-			await PlanTag.createPlanTags(tags);
+		// call it even without tags to update the last_tags_update field
+		await PlanTag.createPlanTags(plan.id, tags);
+
+		if (tags && tags.length > 0) {
 			tagCounter++;
 		}
+
 	}
 	let end = Number(Date.now());
 	const duration = end - start;

--- a/server/api/model/plan.js
+++ b/server/api/model/plan.js
@@ -549,11 +549,13 @@ class Plan extends Model {
 		}).then(res=> res.models);
 	}
 
-	// TODO: actually get the plans we want to tag today, for now getting all of them in dev
 	static async getPlansToTag (options) {
+
 		return Plan.query(qb => {
+			qb.where('last_tags_update', '<', Knex.raw('updated_at'));
+
 			if (options && options.OBJECTID) {
-				qb.where('OBJECTID', '=', options.OBJECTID);
+				qb.andWhere('OBJECTID', '=', options.OBJECTID);
 			}
 		}).fetchAll({
 			columns: [

--- a/server/migrations/20220129115321_add_last_tags_update.js
+++ b/server/migrations/20220129115321_add_last_tags_update.js
@@ -1,0 +1,15 @@
+
+exports.up = function(knex) {
+    return knex.schema.table('plan', table => {
+        // some default time
+        table.dateTime('last_tags_update').notNullable().defaultTo('2000-01-01 00:00:01');
+    })
+};
+
+exports.down = function(knex) {
+    return knex.schema.table('plan', table => {
+        table.dropColumns(
+            'last_tags_update'
+        );
+    });
+};


### PR DESCRIPTION
I made the adjustments for updatePlanTags in order for us to call it from a cron job.
It updates the tags of the necessary plans only.

Closes #393