### PR TITLE
Create developer and produt Wiki

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,18 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v2
+
+      - name: Deploy Documentation
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs
+      - run: mkdocs gh-deploy --force --clean --verbose

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+# Welcome to Merimi
+
+For full documentation visit [meirim.org](https://meirim.org/).
+
+Our Github repository is in [meirim-org/meirim](https://github.com/meirim-org/meirim).
+
+## Sections
+
+- [Basics](basics)
+- [Backend](backend)
+- [Crawler](crawler)
+- [Frontend](frontend)
+- [Utilities](utilities)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: Meirim.org


### PR DESCRIPTION
Closes create developer & product wiki #576.

Wraps existing documentation with mkdocs [1].
Deploys to Github Pages [2] using Github Actions reference from [3].

[1] https://squidfunk.github.io/mkdocs-material/
[2] https://www.mkdocs.org/user-guide/deploying-your-docs/ [3] https://blog.elmah.io/deploying-a-mkdocs-documentation-site-with-github-actions/