### PR TITLE
added a small script to add MP_ID to plans

### DIFF
--- a/server/api/lib/iplanApi.js
+++ b/server/api/lib/iplanApi.js
@@ -120,5 +120,6 @@ const getPlanningCouncils = () => {
 
 module.exports = {
 	getBlueLines,
-	getPlanningCouncils
+	getPlanningCouncils,
+	buildMavatURL
 };

--- a/server/api/model/plan.js
+++ b/server/api/model/plan.js
@@ -104,7 +104,8 @@ class Plan extends Model {
 	_creating (model) {
 		return new Promise((resolve) => {
 			// set the geometry's centroid using ST_Centroid function
-			model.set('geom_centroid', Knex.raw('ST_Centroid(geom)'));
+			//TODO: return this after the MP_ID migration
+			// model.set('geom_centroid', Knex.raw('ST_Centroid(geom)'));
 			resolve();
 		});
 	}

--- a/server/bin/scrap_mp_id
+++ b/server/bin/scrap_mp_id
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+const controller = require('../api/controller/cron');
+const Log = require('../api/lib/log');
+
+const run = async () => {
+	try {
+		Log.info('running scrap_mp_id');
+		await controller.fillMPIDForMissingPlans();
+	}
+	catch(e){
+		Log.error('Running scrap_mp_id' + e);
+	}
+	finally{ 
+		process.exit();
+	}
+};
+
+
+run();


### PR DESCRIPTION
resolves #601 
This script is to fill plans from old MAVAT with MP ID received from the BLUE Lines API (they added this field also to old plans)

It runs at pulses of 20 plans, will ran it with crontab every 1 minute. There are 22K plans to run this script on